### PR TITLE
FEAT: 설정/알림 API 연동

### DIFF
--- a/app/(tabs)/myPage/setting/appSetting.tsx
+++ b/app/(tabs)/myPage/setting/appSetting.tsx
@@ -119,7 +119,7 @@ export default function AppSetting() {
           </TouchableOpacity>
         </View>
         {/* 최근 알림 미리보기 */}
-        <View style={{ paddingHorizontal: 20, paddingTop: 12 }}>
+        {/* <View style={{ paddingHorizontal: 20, paddingTop: 12 }}>
           <Text style={styles.sectionTitle}>최근 알림</Text>
           {loading ? (
             <ActivityIndicator style={{ marginTop: 16 }} />
@@ -151,8 +151,8 @@ export default function AppSetting() {
                 </View>
               )}
             />
-          )}
-        </View>
+          )} // 왜 있는 거지???
+        </View> */}
       </View>
     </SafeAreaView>
   );

--- a/app/(tabs)/myPage/setting/appSetting.tsx
+++ b/app/(tabs)/myPage/setting/appSetting.tsx
@@ -118,41 +118,6 @@ export default function AppSetting() {
             <Text style={styles.itemText}>문의하기</Text>
           </TouchableOpacity>
         </View>
-        {/* 최근 알림 미리보기 */}
-        {/* <View style={{ paddingHorizontal: 20, paddingTop: 12 }}>
-          <Text style={styles.sectionTitle}>최근 알림</Text>
-          {loading ? (
-            <ActivityIndicator style={{ marginTop: 16 }} />
-          ) : errorText ? (
-            <Text style={styles.errorText}>{errorText}</Text>
-          ) : (
-            <FlatList
-              data={notis.slice(0, 5)}
-              keyExtractor={(item, idx) => item.id ?? String(idx)}
-              contentContainerStyle={{ paddingTop: 8, paddingBottom: 20 }}
-              ListEmptyComponent={
-                <Text style={styles.emptyText}>알림이 없습니다.</Text>
-              }
-              renderItem={({ item }) => (
-                <View style={styles.notiItem}>
-                  <Text style={styles.notiTitle}>
-                    {item.title || item.message || item.type || '알림'}
-                  </Text>
-                  {item.body || item.message ? (
-                    <Text style={styles.notiBody} numberOfLines={2}>
-                      {item.body || item.message}
-                    </Text>
-                  ) : null}
-                  {item.createdAt ? (
-                    <Text style={styles.notiTime}>
-                      {new Date(item.createdAt).toLocaleString()}
-                    </Text>
-                  ) : null}
-                </View>
-              )}
-            />
-          )} // 왜 있는 거지???
-        </View> */}
       </View>
     </SafeAreaView>
   );

--- a/app/(tabs)/myPage/setting/notification.tsx
+++ b/app/(tabs)/myPage/setting/notification.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
 import React, { useEffect, useRef, useState } from 'react';
 import {
+  Alert,
   Animated,
   Easing,
   SafeAreaView,
@@ -13,13 +14,16 @@ import {
 
 import BackArrow from '@/assets/icons/back-arrow.svg';
 import { Typography } from '@/constants/typography';
+import axios from 'axios';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 type ToggleProps = {
   value: boolean;
   onChange: (v: boolean) => void;
+  disabled?: boolean;
 };
 
-function CustomToggle({ value, onChange }: ToggleProps) {
+function CustomToggle({ value, onChange, disabled }: ToggleProps) {
   const progress = useRef(new Animated.Value(value ? 1 : 0)).current;
 
   useEffect(() => {
@@ -51,8 +55,6 @@ function CustomToggle({ value, onChange }: ToggleProps) {
   );
 }
 
-// ---------------------------
-
 type NotiKey =
   | 'all'
   | 'dailyRecommendation'
@@ -61,17 +63,82 @@ type NotiKey =
   | 'recommendationMissed'
   | 'serviceAnnouncement';
 
+// 백엔드 페이로드(그대로)
+type BackendPayload = {
+  recomsSent: boolean;
+  recomsReceived: boolean;
+  commentArrived: boolean;
+  notRecoms: boolean;
+  announcement: boolean;
+};
+
+type NotiState = Record<NotiKey, boolean>;
+
+function fromApi(data: BackendPayload): NotiState {
+  const s: NotiState = {
+    all: false,
+    dailyRecommendation: data.recomsReceived ?? false,
+    myRecommendationSent: data.recomsSent ?? false,
+    commentReceived: data.commentArrived ?? false,
+    recommendationMissed: data.notRecoms ?? false,
+    serviceAnnouncement: data.announcement ?? false,
+  };
+  s.all =
+    s.dailyRecommendation &&
+    s.myRecommendationSent &&
+    s.commentReceived &&
+    s.recommendationMissed &&
+    s.serviceAnnouncement;
+  return s;
+}
+
+function toApi(state: NotiState): BackendPayload {
+  return {
+    recomsSent: state.myRecommendationSent,
+    recomsReceived: state.dailyRecommendation,
+    commentArrived: state.commentReceived,
+    notRecoms: state.recommendationMissed,
+    announcement: state.serviceAnnouncement,
+  };
+}
+
+// !💣💣💣💣💣💣💣💣 API 설정 💣💣💣💣💣💣💣💣!
+const BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+const API_TOKEN = process.env.EXPO_PUBLIC_API_TOKEN;
+
+const ENDPOINT = '/api/v1/users/notification-settings';
+
+const api = axios.create({ baseURL: BASE_URL });
+
+api.interceptors.request.use((cfg) => {
+  if (API_TOKEN) {
+    cfg.headers = cfg.headers ?? {};
+    cfg.headers.Authorization = `Bearer ${API_TOKEN}`;
+  } else {
+    console.log('⚠️ EXPO_PUBLIC_API_TOKEN이 비어 있습니다. 요청이 401 날 수 있어요.');
+  }
+  console.log('➡️', cfg.method?.toUpperCase(), (cfg.baseURL || '') + (cfg.url || ''), cfg.data ?? '');
+  return cfg;
+});
+api.interceptors.response.use(
+  (res) => { console.log('✅', res.status, res.config.url, res.data); return res; },
+  (err) => { console.log('❌', err.response?.status ?? 'NO_STATUS', err.config?.url, err.response?.data ?? err.message); return Promise.reject(err); }
+);
+
+// ! 💣💣💣💣💣💣💣💣 화면 💣💣💣💣💣💣💣💣 !
 export default function Notification() {
   const router = useRouter();
 
-  const [noti, setNoti] = useState<Record<NotiKey, boolean>>({
-    all: true,
-    dailyRecommendation: true,
+  const [noti, setNoti] = useState<NotiState>({
+    all: false,
+    dailyRecommendation: false,
     myRecommendationSent: false,
     commentReceived: false,
     recommendationMissed: false,
     serviceAnnouncement: false,
   });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
 
   const items: { key: NotiKey; label: string }[] = [
     { key: 'all', label: '전체' },
@@ -82,9 +149,64 @@ export default function Notification() {
     { key: 'serviceAnnouncement', label: '서비스 공지사항' },
   ];
 
+  const recomputeAll = (s: NotiState) =>
+    s.dailyRecommendation &&
+    s.myRecommendationSent &&
+    s.commentReceived &&
+    s.recommendationMissed &&
+    s.serviceAnnouncement;
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api.get<BackendPayload>(ENDPOINT);
+        setNoti(fromApi(res.data));
+      } catch {
+        Alert.alert('알림 설정', '설정 조회에 실패했어요. 로그인/네트워크를 확인해주세요.');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  // 저장 (optimistic + 실패 시 롤백)
+  const save = async (next: NotiState, prev: NotiState) => {
+    setNoti(next);
+    setSaving(true);
+    try {
+      await api.patch(ENDPOINT, toApi(next));
+    } catch (e: any) {
+      if (e?.response?.status === 401) {
+        Alert.alert('로그인 필요', '권한이 없어요. EXPO_PUBLIC_API_TOKEN을 확인해주세요.');
+      } else {
+        Alert.alert('알림 설정', '저장에 실패했어요. 다시 시도해주세요.');
+      }
+      setNoti(prev);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const onToggle = (key: NotiKey, value: boolean) => {
-    setNoti((prev) => ({ ...prev, [key]: value }));
-    // TODO: API 연동
+    if (loading || saving) return;
+    const prev = noti;
+    let next: NotiState = { ...noti };
+
+    if (key === 'all') {
+      next = {
+        ...next,
+        all: value,
+        dailyRecommendation: value,
+        myRecommendationSent: value,
+        commentReceived: value,
+        recommendationMissed: value,
+        serviceAnnouncement: value,
+      };
+    } else {
+      next[key] = value;
+      next.all = recomputeAll(next);
+    }
+    save(next, prev);
   };
 
   return (


### PR DESCRIPTION
## 이슈번호 #58 <!-- 이슈 번호를 작성해주세요 ex) #21 -->

### 📌 작업한 내용  
설정/알림 API 연동했습니다

---


### 🔍 참고 사항  
appSetting.tsx에 필요없는 코드가 있어서 일단 주석처리 해 뒀는데 확인 한번 해 주시면 아예 지우고 커밋하겠습니다!! 
<img width="273" height="476" alt="스크린샷 2025-08-15 오전 1 08 04" src="https://github.com/user-attachments/assets/16ec260a-a040-470f-a99e-38684698ef9c" />
이 부분 삭제했어요
---


### 🖼️ 스크린샷  
<img width="683" height="553" alt="스크린샷 2025-08-15 오전 2 44 42" src="https://github.com/user-attachments/assets/07af5836-d33c-413e-a8ba-addc66d67d99" />
제대로 작동합니당

---

### 🔗 관련 이슈  
연관된 이슈를 적어주세요. 

---

### ✅ 체크리스트  
PR을 제출하기 전에 확인해야 할 항목들
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인
